### PR TITLE
Fix auth API responses and improve security

### DIFF
--- a/backend/src/main/java/com/learningplatform/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/learningplatform/backend/controller/AuthController.java
@@ -1,12 +1,15 @@
 package com.learningplatform.backend.controller;
 
 import com.learningplatform.backend.dto.AuthResponse;
+import com.learningplatform.backend.dto.AuthUserResponse;
 import com.learningplatform.backend.dto.LoginRequest;
 import com.learningplatform.backend.dto.RegisterRequest;
 import com.learningplatform.backend.model.User;
 import com.learningplatform.backend.service.AuthService;
 import com.learningplatform.backend.common.response.ApiResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,9 +24,11 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ApiResponse<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+    public ResponseEntity<ApiResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest request) {
         AuthResponse response = authService.register(request);
-        return ApiResponse.success("User registered successfully", response);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("User registered successfully", response));
     }
 
     @PostMapping("/login")
@@ -40,7 +45,12 @@ public class AuthController {
                 .getName();
 
         User user = authService.getCurrentUser(email);
-
-        return ApiResponse.success("User fetched successfully", user);
+        AuthUserResponse response = new AuthUserResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getRole()
+        );
+        return ApiResponse.success("User fetched successfully", response);
     }
 }

--- a/backend/src/main/java/com/learningplatform/backend/security/JwtService.java
+++ b/backend/src/main/java/com/learningplatform/backend/security/JwtService.java
@@ -24,6 +24,7 @@ public class JwtService {
         return Jwts.builder()
                 .subject(user.getEmail())
                 .claim("userId", user.getId())
+                .claim("role", user.getRole().name())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
                 .signWith(getSigningKey())


### PR DESCRIPTION
- Updated /api/auth/me to return DTO instead of entity (removed password exposure)
- Removed password field from /api/auth/me response to prevent sensitive data exposure
- Changed register endpoint to return HTTP 201 Created
- Included role claim in JWT token
- Improved overall API response consistency