### PR TITLE
fix: use VITE_API_BASE_URL env var for Axios baseURL

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: '/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const api = axios.create({ baseURL: '/api' });
+const api = axios.create({ baseURL: import.meta.env.VITE_API_BASE_URL || '/api' });
 
 api.interceptors.request.use(config => {
   const token = localStorage.getItem('token');


### PR DESCRIPTION
Falls back to '/api' so local dev Vite proxy continues to work. Fixes production deployments on Vercel pointing to the EC2 backend.