### PR TITLE
[Sprint9][Cleanup] Frontend Code Cleanup — Student Pages — Bingyan

### DIFF
--- a/frontend/src/pages/CourseDetail.jsx
+++ b/frontend/src/pages/CourseDetail.jsx
@@ -9,7 +9,6 @@ import { buildBackendUrl } from '../api/baseUrl';
 import { announcementApi, assignmentApi, courseApi, forumApi } from '../api';
 import { getApiErrorState } from '../lib/apiState';
 import {
-  formatDiscussionResetText,
   hasReachedDiscussionLimit,
   incrementDiscussionUsage,
   loadDiscussionMembershipState,
@@ -497,9 +496,6 @@ export default function CourseDetail() {
   const discussionLimitReached = hasReachedDiscussionLimit(discussionMembership);
   const discussionUsageText = discussionMembership && !discussionMembership.isMember
     ? `${discussionMembership.weeklyPostsUsed ?? 0} of ${discussionMembership.weeklyPostsLimit ?? 10} posts used this week — ${discussionMembership.remaining ?? 0} remaining`
-    : '';
-  const discussionResetText = discussionMembership && !discussionMembership.isMember
-    ? formatDiscussionResetText(discussionMembership.resetsAt)
     : '';
 
   function canDeleteDiscussionItem(authorId) {

--- a/frontend/src/pages/Forum.jsx
+++ b/frontend/src/pages/Forum.jsx
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import EmptyState from '../components/shared/EmptyState';
 import ErrorState from '../components/shared/ErrorState';
 import { courseApi, forumApi } from '../api';
 import { useAuth } from '../lib/auth';
 import { getApiErrorState } from '../lib/apiState';
 import {
-  formatDiscussionResetText,
   hasReachedDiscussionLimit,
   loadDiscussionMembershipState,
 } from '../lib/discussionMembership';
@@ -130,9 +128,6 @@ export default function Forum() {
   const discussionLimitReached = hasReachedDiscussionLimit(discussionMembership);
   const discussionUsageText = discussionMembership && !discussionMembership.isMember
     ? `${discussionMembership.weeklyPostsUsed ?? 0} of ${discussionMembership.weeklyPostsLimit ?? 10} posts used this week — ${discussionMembership.remaining ?? 0} remaining`
-    : '';
-  const discussionResetText = discussionMembership && !discussionMembership.isMember
-    ? formatDiscussionResetText(discussionMembership.resetsAt)
     : '';
 
   async function handleDeletePost(courseId, postId) {

--- a/frontend/src/pages/auth/LoginPage.jsx
+++ b/frontend/src/pages/auth/LoginPage.jsx
@@ -13,7 +13,7 @@ const PILLS = ['Discussion forums', 'Assignment management', 'Course materials',
 // ── tiny helpers ─────────────────────────────────────────────────────────────
 
 /** Labelled input field for the auth forms. */
-function Field({ label, error, inputRef, small = false, children }) {
+function Field({ label, error, small = false, children }) {
   return (
     <div style={{ marginBottom: small ? 10 : 15 }}>
       <label

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,5 +1,4 @@
 import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { useAuth } from '../lib/auth';
 import { Navbar, StudentSidebar, InstructorSidebar, LoadingSpinner } from '../components/shared';
 
@@ -11,7 +10,6 @@ import AssignmentSubmission from '../pages/AssignmentSubmission';
 import AssignmentQuiz from '../pages/AssignmentQuiz';
 import AssignmentReview from '../pages/AssignmentReview';
 import Forum from '../pages/Forum';
-// import Assignments from '../pages/Assignments';
 import AssignmentList from '../pages/AssignmentList';
 import Announcements from '../pages/Announcements';
 import InstructorGrading from '../pages/InstructorGrading';
@@ -25,22 +23,6 @@ import InstructorAnalyticsPage from '../pages/instructor/InstructorAnalyticsPage
 import BrowseCourses from '../pages/BrowseCourses';
 import Profile from '../pages/Profile';
 import Membership from '../pages/Membership';
-
-// Temporary placeholder for pages not yet implemented
-function Soon({ page }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '60vh' }}>
-      <div style={{ textAlign: 'center' }}>
-        <span className="material-symbols-rounded" style={{ fontSize: 48, color: '#ddd0d4' }}>
-          construction
-        </span>
-        <p style={{ marginTop: 12, color: '#9c8a8e', fontSize: 14, fontFamily: "'Gowun Batang', serif" }}>
-          {page} — coming soon
-        </p>
-      </div>
-    </div>
-  );
-}
 
 // ── Route guards ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
close #156 
## Summary

- Removed unused imports, props, variables, and placeholder code from student-facing frontend files
- Removed dead commented-out route import from the app router
- Kept API, Vercel, backend, routing behavior, UI layout, and business logic unchanged

## Changes

- `CourseDetail.jsx`: removed unused discussion reset text calculation/import
- `Forum.jsx`: removed unused `EmptyState` import and unused discussion reset text calculation/import
- `LoginPage.jsx`: removed unused `inputRef` prop from the auth field wrapper
- `router/index.jsx`: removed unused `PropTypes`, commented-out import, and unused `Soon` placeholder component

## Verification

- `npm run build` completed successfully
- Targeted unused-variable check passed for student-facing pages and shared components
- Confirmed no `console.` or `localhost` matches in the student-facing cleanup scope