### PR TITLE
[Sprint9][Backend] Add request logging for Render smoke testing #160

### DIFF
--- a/backend/src/main/java/com/learningplatform/backend/security/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/learningplatform/backend/security/RequestLoggingFilter.java
@@ -1,0 +1,34 @@
+package com.learningplatform.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestLoggingFilter.class);
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        filterChain.doFilter(request, response);
+
+        log.info("{} {} -> {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                response.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
Implemented:
- Added RequestLoggingFilter for Render smoke testing
- Added lightweight API request logging
- Verified frontend requests reach Render backend

Closes #97