### PR TITLE
Clarify membership resubmission limit display

### DIFF
--- a/frontend/src/pages/Membership.jsx
+++ b/frontend/src/pages/Membership.jsx
@@ -49,10 +49,8 @@ export default function Membership() {
   const isPremium = upgraded || (mem && mem.type !== 'FREE');
   const postsUsed = mem?.usage?.weeklyPostsUsed ?? 0;
   const postsLimit = mem?.usage?.weeklyPostsLimit ?? 10;
-  const resubUsed = mem?.usage?.resubmissionsUsed ?? 0;
   const resubLimit = mem?.usage?.resubmissionsLimit ?? 2;
   const postsPercent = isPremium ? 100 : Math.min(100, (postsUsed / postsLimit) * 100);
-  const resubPercent = isPremium ? 100 : Math.min(100, (resubUsed / resubLimit) * 100);
 
   function formatCardNumber(val) {
     return val.replace(/\D/g, '').slice(0, 16).replace(/(.{4})/g, '$1 ').trim();
@@ -135,7 +133,7 @@ export default function Membership() {
       {/* Usage tracker */}
       <div className="mem-page-card">
         <div style={{ fontSize: 13, color: 'var(--text-dark)', marginBottom: 14, fontWeight: 500 }}>
-          This week's usage
+          Discussion usage this week
         </div>
         <div className="mem-usage-row">
           <div className="mem-usage-label">Discussion posts</div>
@@ -151,18 +149,15 @@ export default function Membership() {
         </div>
         <div className="mem-usage-row">
           <div className="mem-usage-label">Assignment resubmissions</div>
-          <div className="mem-usage-bar-wrap">
-            <div
-              className={`mem-usage-bar${isPremium ? ' ok' : resubPercent >= 50 ? ' warn' : ''}`}
-              style={{ width: isPremium ? '0%' : `${resubPercent}%` }}
-            />
+          <div style={{ flex: 1, fontSize: 11, color: 'var(--text-muted)' }}>
+            Per-assignment limit
           </div>
           <div className="mem-usage-count">
-            {isPremium ? '∞ / ∞' : `${resubUsed} / ${resubLimit}`}
+            {isPremium ? '∞ each' : `${resubLimit} each`}
           </div>
         </div>
         <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 12 }}>
-          ⏱ Limits reset {nextMondayLabel()} at 12:00am AEST
+          ⏱ Discussion limit resets {nextMondayLabel()} at 12:00am AEST
         </div>
       </div>
 

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -502,7 +502,7 @@ export default function Profile() {
                   {isPremium
                     ? 'Unlimited posts and resubmissions'
                     : memData
-                      ? `${memData.usage?.weeklyPostsUsed ?? 0} / ${memData.usage?.weeklyPostsLimit ?? 0} posts used this week · ${memData.usage?.resubmissionsUsed ?? 0} / ${memData.usage?.resubmissionsLimit ?? 0} resubmissions used`
+                      ? `${memData.usage?.weeklyPostsUsed ?? 0} / ${memData.usage?.weeklyPostsLimit ?? 0} posts used this week · ${memData.usage?.resubmissionsLimit ?? 0} resubmissions per assignment`
                       : 'Limited posts and resubmissions'}
                 </div>
               </div>


### PR DESCRIPTION
#184 

Changes:

Renamed the Membership usage heading to Discussion usage this week.
Replaced the resubmission usage bar with a Per-assignment limit row.
Updated Profile membership summary to say resubmissions per assignment.
Removed frontend reads of usage.resubmissionsUsed from these displays.
Validation:

Confirmed API failure still renders the Membership error state instead of defaulting to Free plan UI.
Confirmed only Membership.jsx and Profile.jsx changed.
No API or backend changes.